### PR TITLE
Decompose iteration names into components

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-04.txt
@@ -1,7 +1,7 @@
 +++ Running test-04 pbench-fio
 pbench-fio
 python-pandas
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -25,12 +25,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-rw-4KiB (1 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -54,12 +54,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-rw-4KiB (1 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -83,12 +83,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-rw-4KiB (1 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -112,12 +112,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-rw-4KiB (1 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -141,12 +141,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-rw-4KiB (1 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -170,12 +170,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 1-rw-4KiB complete (1 of 6), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -199,12 +199,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-rw-64KiB (2 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -228,12 +228,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-rw-64KiB (2 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -257,12 +257,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-rw-64KiB (2 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -286,12 +286,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-rw-64KiB (2 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -315,12 +315,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-rw-64KiB (2 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -344,12 +344,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 2-rw-64KiB complete (2 of 6), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -373,12 +373,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-rw-1024KiB (3 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -402,12 +402,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-rw-1024KiB (3 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -431,12 +431,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-rw-1024KiB (3 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -460,12 +460,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-rw-1024KiB (3 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -489,12 +489,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-rw-1024KiB (3 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -518,12 +518,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 3-rw-1024KiB complete (3 of 6), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -547,12 +547,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 4-randrw-4KiB (4 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -576,12 +576,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 4-randrw-4KiB (4 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -605,12 +605,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 4-randrw-4KiB (4 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -634,12 +634,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 4-randrw-4KiB (4 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -663,12 +663,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 4-randrw-4KiB (4 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -692,12 +692,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 4-randrw-4KiB complete (4 of 6), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -721,12 +721,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 5-randrw-64KiB (5 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -750,12 +750,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 5-randrw-64KiB (5 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -779,12 +779,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 5-randrw-64KiB (5 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -808,12 +808,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 5-randrw-64KiB (5 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -837,12 +837,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 5-randrw-64KiB (5 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -866,12 +866,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 5-randrw-64KiB complete (5 of 6), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -895,12 +895,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 6-randrw-1024KiB (6 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -924,12 +924,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 6-randrw-1024KiB (6 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -953,12 +953,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 6-randrw-1024KiB (6 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -982,12 +982,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 6-randrw-1024KiB (6 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -1011,12 +1011,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 6-randrw-1024KiB (6 of 6)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -1040,13 +1040,13 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 6-randrw-1024KiB complete (6 of 6), with 1 pass and 6 failures
 # these results generated with:
-# pbench-fio --test-types=rw,randrw
+# pbench-fio --config=test-04 --test-types=rw,randrw
 
 
 
@@ -1063,49 +1063,50 @@ Iteration 6-randrw-1024KiB complete (6 of 6), with 1 pass and 6 failures
 --- Finished test-04 pbench-fio (status=0}
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.csv
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.html
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.txt
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/metadata.log
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/summary-result.csv
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/summary-result.html
+/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
-/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01T00:00:00.iterations
+/var/tmp/pbench-test-bench/pbench/tmp/fio_test-04_1900-01-01T00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
@@ -1114,296 +1115,334 @@ Iteration 6-randrw-1024KiB complete (6 of 6), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 2.14 is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]python-pandas is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio_device_check() /tmp/fio 
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-rw-4KiB (1 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-rw-4KiB (1 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-rw-4KiB (1 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-rw-4KiB (1 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-rw-4KiB (1 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1 1-rw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 1-rw-4KiB complete (1 of 6), with 1 pass and 6 failures
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-rw-64KiB (2 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-rw-64KiB (2 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-rw-64KiB (2 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-rw-64KiB (2 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-rw-64KiB (2 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1 2-rw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-rw-64KiB complete (2 of 6), with 1 pass and 6 failures
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-rw-1024KiB (3 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-rw-1024KiB (3 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-rw-1024KiB (3 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-rw-1024KiB (3 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-rw-1024KiB (3 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1 3-rw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 3-rw-1024KiB complete (3 of 6), with 1 pass and 6 failures
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 4-randrw-4KiB (4 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 4-randrw-4KiB (4 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 4-randrw-4KiB (4 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 4-randrw-4KiB (4 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 4-randrw-4KiB (4 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1 4-randrw-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 4-randrw-4KiB complete (4 of 6), with 1 pass and 6 failures
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 5-randrw-64KiB (5 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 5-randrw-64KiB (5 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 5-randrw-64KiB (5 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 5-randrw-64KiB (5 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 5-randrw-64KiB (5 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1 5-randrw-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 5-randrw-64KiB complete (5 of 6), with 1 pass and 6 failures
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 6-randrw-1024KiB (6 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 6-randrw-1024KiB (6 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 6-randrw-1024KiB (6 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 6-randrw-1024KiB (6 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 6-randrw-1024KiB (6 of 6)
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job ]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1 6-randrw-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 6-randrw-1024KiB complete (6 of 6), with 1 pass and 6 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 beg
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-rw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-rw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-rw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/4-randrw-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/5-randrw-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-rw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/1-rw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-rw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/2-rw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-rw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/3-rw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=4-randrw-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/4-randrw-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=5-randrw-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/5-randrw-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=6-randrw-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-04_1900-01-01T00:00:00/6-randrw-1024KiB/sample1
 --- test-execution.log file contents
+[pbench]
+
+[iterations/1-rw-4KiB]
+iteration_number = 1
+test_type = rw
+block_size_kib = 4
+iteration_name = 1-rw-4KiB
+
+[iterations/2-rw-64KiB]
+iteration_number = 2
+test_type = rw
+block_size_kib = 64
+iteration_name = 2-rw-64KiB
+
+[iterations/3-rw-1024KiB]
+iteration_number = 3
+test_type = rw
+block_size_kib = 1024
+iteration_name = 3-rw-1024KiB
+
+[iterations/4-randrw-4KiB]
+iteration_number = 4
+test_type = randrw
+block_size_kib = 4
+iteration_name = 4-randrw-4KiB
+
+[iterations/5-randrw-64KiB]
+iteration_number = 5
+test_type = randrw
+block_size_kib = 64
+iteration_name = 5-randrw-64KiB
+
+[iterations/6-randrw-1024KiB]
+iteration_number = 6
+test_type = randrw
+block_size_kib = 1024
+iteration_name = 6-randrw-1024KiB
+

--- a/agent/bench-scripts/gold/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-05.txt
@@ -2,7 +2,7 @@
 pbench-fio
 verifying clients have fio installed
 python-pandas
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -26,12 +26,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -55,12 +55,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -84,12 +84,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -113,12 +113,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -142,12 +142,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -171,12 +171,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 1-throughput-4KiB complete (1 of 3), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -200,12 +200,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -229,12 +229,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -258,12 +258,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -287,12 +287,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -316,12 +316,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -345,12 +345,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 2-throughput-64KiB complete (2 of 3), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -374,12 +374,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -403,12 +403,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -432,12 +432,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -461,12 +461,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -490,12 +490,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -519,13 +519,13 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 # these results generated with:
-# pbench-fio --test-type=throughput --samples=1 --clients=foo,bar
+# pbench-fio --config=test-05 --test-type=throughput --samples=1 --clients=foo,bar
 
 
 
@@ -537,31 +537,32 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 --- Finished test-05 pbench-fio (status=0}
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.csv
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.html
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.txt
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/metadata.log
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/summary-result.csv
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/summary-result.html
+/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
-/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01T00:00:00.iterations
+/var/tmp/pbench-test-bench/pbench/tmp/fio_test-05_1900-01-01T00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
@@ -575,294 +576,294 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 1-throughput-4KiB complete (1 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-throughput-64KiB complete (2 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job  --client=foo --client=bar --max-jobs=2]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 beg
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=foo --client=bar --max-jobs=2 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
@@ -899,61 +900,61 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /opt/pbench-agent/bench-scripts/pbench-fio --remote-only --install
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
@@ -990,41 +991,61 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /opt/pbench-agent/bench-scripts/pbench-fio --remote-only --install
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-05_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
 --- test-execution.log file contents
+[pbench]
+
+[iterations/1-throughput-4KiB]
+iteration_number = 1
+test_type = throughput
+block_size_kib = 4
+iteration_name = 1-throughput-4KiB
+
+[iterations/2-throughput-64KiB]
+iteration_number = 2
+test_type = throughput
+block_size_kib = 64
+iteration_name = 2-throughput-64KiB
+
+[iterations/3-throughput-1024KiB]
+iteration_number = 3
+test_type = throughput
+block_size_kib = 1024
+iteration_name = 3-throughput-1024KiB
+

--- a/agent/bench-scripts/gold/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-06.txt
@@ -2,7 +2,7 @@
 pbench-fio
 verifying clients have fio installed
 python-pandas
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -26,12 +26,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -55,12 +55,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -84,12 +84,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -113,12 +113,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -142,12 +142,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 1-throughput-4KiB (1 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 [global]
 bs=4k
 runtime=30
@@ -171,12 +171,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 1-throughput-4KiB complete (1 of 3), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -200,12 +200,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -229,12 +229,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -258,12 +258,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -287,12 +287,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -316,12 +316,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 2-throughput-64KiB (2 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 [global]
 bs=64k
 runtime=30
@@ -345,12 +345,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 2-throughput-64KiB complete (2 of 3), with 1 pass and 6 failures
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -374,12 +374,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -403,12 +403,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -432,12 +432,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -461,12 +461,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -490,12 +490,12 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Restarting iteration 3-throughput-1024KiB (3 of 3)
-The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+The following jobfile was created: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 [global]
 bs=1024k
 runtime=30
@@ -519,13 +519,13 @@ write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
 
-running fio job: /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
 fio job complete
 Chart Type: xy
 Could not find any json data, exiting
 Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 # these results generated with:
-# pbench-fio --test-type=throughput --samples=1 --client-file=/tmp/foo
+# pbench-fio --config=test-06 --test-type=throughput --samples=1 --client-file=/tmp/foo
 
 
 
@@ -537,32 +537,33 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 --- Finished test-06 pbench-fio (status=0}
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail1.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail2.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail3.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail4.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail5.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB-fail6.tar.xz
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/fio-client.file
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.csv
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.html
-/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/summary-result.txt
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail1.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail2.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail3.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail4.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail5.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB-fail6.tar.xz
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/fio-client.file
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/metadata.log
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/summary-result.csv
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/summary-result.html
+/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
-/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01T00:00:00.iterations
+/var/tmp/pbench-test-bench/pbench/tmp/fio_test-06_1900-01-01T00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
@@ -576,312 +577,312 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 1-throughput-4KiB (1 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 1-throughput-4KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 1-throughput-4KiB complete (1 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 2-throughput-64KiB (2 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 2-throughput-64KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-throughput-64KiB complete (2 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Restarting iteration 3-throughput-1024KiB (3 of 3)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] creating directories on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] opening port 8765 on firewall on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job --client=/tmp/foo --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] getting log files from clients
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] failed: /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 3-throughput-1024KiB default
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 beg
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/tmp/foo --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-throughput-4KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-throughput-64KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3-throughput-1024KiB --dir=/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no bar:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/bar/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no baz:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/baz/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/scp -o StrictHostKeyChecking=no foo:/var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/clients/foo/
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
@@ -918,61 +919,61 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar /opt/pbench-agent/bench-scripts/pbench-fio --remote-only --install
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no bar pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
@@ -1009,61 +1010,61 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz /opt/pbench-agent/bench-scripts/pbench-fio --remote-only --install
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no baz pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /bin/rm -f /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1/*.log
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
@@ -1100,41 +1101,61 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo mkdir -p /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo /opt/pbench-agent/bench-scripts/pbench-fio --remote-only --install
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio__1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/1-throughput-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/2-throughput-64KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no foo pushd /var/tmp/pbench-test-bench/pbench/fio_test-06_1900-01-01T00:00:00/3-throughput-1024KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
 --- test-execution.log file contents
+[pbench]
+
+[iterations/1-throughput-4KiB]
+iteration_number = 1
+test_type = throughput
+block_size_kib = 4
+iteration_name = 1-throughput-4KiB
+
+[iterations/2-throughput-64KiB]
+iteration_number = 2
+test_type = throughput
+block_size_kib = 64
+iteration_name = 2-throughput-64KiB
+
+[iterations/3-throughput-1024KiB]
+iteration_number = 3
+test_type = throughput
+block_size_kib = 1024
+iteration_name = 3-throughput-1024KiB
+

--- a/agent/bench-scripts/gold/pbench-uperf/test-00.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-00.txt
@@ -45,6 +45,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01T00:00:00/2-tcp_stream-64B-1i/sample2/uperf-average.txt
 /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01T00:00:00/2-tcp_stream-64B-1i/sample2/uperf-postprocess.cmd
 /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01T00:00:00/generate-benchmark-summary.cmd
+/var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01T00:00:00/metadata.log
 /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01T00:00:00/pbench-uperf.cmd
 --- pbench tree state
 +++ pbench.log file contents
@@ -124,3 +125,21 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
 --- test-execution.log file contents
+[pbench]
+
+[iterations/1-tcp_rr-64B-1i]
+iteration_number = 1
+protocol = tcp
+test_type = rr
+message_size_bytes = 64
+instances = 1
+iteration_name = 1-tcp_rr-64B-1i
+
+[iterations/2-tcp_stream-64B-1i]
+iteration_number = 2
+protocol = tcp
+test_type = stream
+message_size_bytes = 64
+instances = 1
+iteration_name = 2-tcp_stream-64B-1i
+

--- a/agent/bench-scripts/gold/pbench-uperf/test-01.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-01.txt
@@ -65,6 +65,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01T00:00:00/2-tcp_stream-64B-1i/sample2/uperf-average.txt
 /var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01T00:00:00/2-tcp_stream-64B-1i/sample2/uperf-postprocess.cmd
 /var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01T00:00:00/generate-benchmark-summary.cmd
+/var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01T00:00:00/metadata.log
 /var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01T00:00:00/pbench-uperf.cmd
 --- pbench tree state
 +++ pbench.log file contents
@@ -286,3 +287,21 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no s3 systemctl stop firewalld
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no s3 systemctl stop firewalld
 --- test-execution.log file contents
+[pbench]
+
+[iterations/1-tcp_rr-64B-1i]
+iteration_number = 1
+protocol = tcp
+test_type = rr
+message_size_bytes = 64
+instances = 1
+iteration_name = 1-tcp_rr-64B-1i
+
+[iterations/2-tcp_stream-64B-1i]
+iteration_number = 2
+protocol = tcp
+test_type = stream
+message_size_bytes = 64
+instances = 1
+iteration_name = 2-tcp_stream-64B-1i
+

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -387,6 +387,20 @@ function fio_process_options() {
 	verify_tool_group $tool_group
 }
 
+function record_iteration {
+	local count=$1
+	local test_type=$2
+	local block_size=$3
+	local iteration=$4
+
+	mdlog=${benchmark_run_dir}/metadata.log
+	echo ${iteration} >> ${benchmark_iterations}
+	echo $count | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_number
+	echo $test_type | pbench-add-metalog-option ${mdlog} iterations/${iteration} test_type
+	echo $block_size | pbench-add-metalog-option ${mdlog} iterations/${iteration} block_size_KiB
+	echo $iteration | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
+}
+
 
 # Ensure the right version of the benchmark is installed
 function fio_install() {
@@ -641,8 +655,7 @@ function fio_run_benchmark() {
 			for block_size in `echo $block_sizes | sed -e s/,/" "/g`; do
 				job_num=1
 				iteration="${count}-${test_type}-${block_size}KiB"
-				   
-                                echo $iteration >> $benchmark_iterations
+				record_iteration ${count} ${test_type} ${block_size} ${iteration}
 				iteration_dir=$benchmark_run_dir/$iteration
 				result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 				failures=0

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -365,6 +365,7 @@ while true; do
 		;;
 	esac
 done
+
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
 	benchmark_fullname="${benchmark}_${config}_${date}"
@@ -377,7 +378,26 @@ else
 	fi
 	benchmark_fullname=$(basename $benchmark_run_dir)
 fi
+# we'll record the iterations in this file
 benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
+mdlog=${benchmark_run_dir}/metadata.log
+
+function record_iteration {
+	local count=$1
+	local protocol=$2
+	local test_type=$3
+	local message_size=$4
+	local instance=$5
+	local iteration=$6
+
+	echo ${iteration} >> ${benchmark_iterations}
+	echo $count | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_number
+	echo $protocol | pbench-add-metalog-option ${mdlog} iterations/${iteration} protocol
+	echo $test_type | pbench-add-metalog-option ${mdlog} iterations/${iteration} test_type
+	echo $message_size | pbench-add-metalog-option ${mdlog} iterations/${iteration} message_size_bytes
+	echo $instance | pbench-add-metalog-option ${mdlog} iterations/${iteration} instances
+	echo $iteration | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
+}
 
 # Verify the tool group exists
 verify_tool_group $tool_group
@@ -475,7 +495,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 					echo "Starting iteration $iteration ($count of $total_iterations)"
 					log "Starting iteration $iteration ($count of $total_iterations)"
 					iteration="${count}-${protocol}_${test_type}-${message_size}B-${instance}i"
-                                        echo $iteration >> $benchmark_iterations
+                                        record_iteration ${count} ${protocol} ${test_type} ${message_size} ${instance} ${iteration}
 					iteration_dir="$benchmark_run_dir/$iteration"
 					result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 					failures=0

--- a/agent/bench-scripts/test-bin/pbench-add-metalog-option
+++ b/agent/bench-scripts/test-bin/pbench-add-metalog-option
@@ -1,0 +1,1 @@
+../../util-scripts/pbench-add-metalog-option

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -89,6 +89,9 @@ function _dump_logs {
     grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log | sort >> $_testout 2>&1
     echo "--- test-execution.log file contents" >> $_testout
     rm -f $_testroot/test-execution.log
+    if [ ! -z "$1" ] ;then
+        cat $_testdir/$1/metadata.log >> $_testout 2>&1
+    fi
 }
 function _verify_output {
     sts=$1
@@ -116,6 +119,10 @@ function _setup_state {
         exit 1
     fi
     cp -a $_tdir/sample-tools/tools-default $_testdir/
+    if [ ! -z "$1" ] ;then
+        mkdir -p $_testdir/$1
+        echo [pbench] > $_testdir/$1/metadata.log
+    fi
 }
 function _reset_state {
     rm -rf $_testdir
@@ -132,11 +139,20 @@ declare -A cmds=(
     [test-01]="pbench-uperf  --config=test-01  --test-types=rr,stream  --message-sizes=64  --instances=1  --protocols=tcp  --runtime=20  --samples=2  --servers=s1,s2,s3  --clients=c1,c2,c3  --server-node=0,-1,2  --client-node=1,-1,3"
     [test-02]="pbench-dbench --threads=24,48  --client-nodes=0,1  --clients=127.0.0.1,127.0.0.1  --max-stddev=10"
     [test-03]="pbench-moongen --test-type=throughput --samples=3 --search-runtime=10 --validation-runtime=10 --max-drop-pct=0,1 --frame-sizes=64,1024"
-    [test-04]="pbench-fio --test-types=rw,randrw"
-    [test-05]="pbench-fio --test-type=throughput --samples=1 --clients=foo,bar"
-    [test-06]="pbench-fio --test-type=throughput --samples=1 --client-file=/tmp/foo"
+    [test-04]="pbench-fio --config=test-04 --test-types=rw,randrw"
+    [test-05]="pbench-fio --config=test-05 --test-type=throughput --samples=1 --clients=foo,bar"
+    [test-06]="pbench-fio --config=test-06  --test-type=throughput --samples=1 --client-file=/tmp/foo"
 )
 
+date="1900-01-01T00:00:00"
+declare -A rundirs=(
+    [test-00]="uperf_test-00_$date"
+    [test-01]="uperf_test-01_$date"
+    [test-04]="fio_test-04_$date"
+    [test-05]="fio_test-05_$date"
+    [test-06]="fio_test-06_$date"
+    
+)
 declare -A pre=(
     [test-06]="echo foo bar baz | tr ' ' '\n' > /tmp/foo"
 )
@@ -158,7 +174,7 @@ for tst in $tests; do
     benchmark=${cmd## }
     tpre=${pre[$tst]}
     tpost=${post[$tst]}
-    _setup_state
+    _setup_state ${rundirs[$tst]}
     if [ ! -z "$tpre" ] ;then
         eval "$tpre"
     fi
@@ -168,7 +184,7 @@ for tst in $tests; do
         eval "$tpost"
     fi
     _save_tree
-    _dump_logs
+    _dump_logs ${rundirs[$tst]}
     _verify_output $res $tst $benchmark
     res=$?
     let errs=$errs+$res

--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -1,8 +1,8 @@
 #! /usr/bin/env python2
 
-# Usage: pbench-add-metalog-option <options.file> <metadata log file> <option>
+# Usage: pbench-add-metalog-option <metadata log file> <section> <option>
 
-# Add an option to the [pbench] section of the metadata.log file.
+# Add an option to a section of the metadata.log file.
 # E.g. using an 'iterations' arg for the option
 #
 # iterations: 1-iter, 2-iter, 3-iter
@@ -12,22 +12,26 @@
 import sys
 try:
     # python3
-    from configparser import SafeConfigParser
+    from configparser import SafeConfigParser, NoSectionError
 except:
-    from ConfigParser import SafeConfigParser
+    from ConfigParser import SafeConfigParser, NoSectionError
 
-def main(ifile, lfile, section):
-   config = SafeConfigParser()
-   config.read(lfile)
-   # python3
-   # config['pbench']['iterations'] = ', '.join(open(ifile).read().split())
-   config.set('pbench', section, ', '.join(open(ifile).read().split()))
-   config.write(open(lfile, "w"))
+def main(lfile, section, option):
+    config = SafeConfigParser()
+    config.read(lfile)
+    # python3
+    # config[section][option] = ', '.join(sys.stdin.read().split())
+    sin = sys.stdin.read()
+    try:
+        config.set(section, option, ', '.join(sin.split()))
+    except NoSectionError:
+        config.add_section(section)
+        config.set(section, option, ', '.join(sin.split()))
+    config.write(open(lfile, "w"))
    
 if __name__ == '__main__':
-   ifile = sys.argv[1]
-   lfile = sys.argv[2]
-   section = sys.argv[3]
-   status = main(ifile, lfile, section)
+   lfile = sys.argv[1]
+   section = sys.argv[2]
+   option = sys.argv[3]
+   status = main(lfile, section, option)
    sys.exit(status)
-   

--- a/agent/util-scripts/pbench-metadata-log
+++ b/agent/util-scripts/pbench-metadata-log
@@ -167,10 +167,10 @@ function metadata_log_end {
         metadata_log_start $dir $group $start_ts
     fi
     if ! grep -q end_run $log ;then
-        echo "end_run: $(timestamp)" >> $log
+        echo "$(timestamp)" | pbench-add-metalog-option $dir/metadata.log run end_run
     fi
     if [ "$int" == "int" ] ;then
-        echo "run_interrupted: true" >> $log
+        echo "true"  | pbench-add-metalog-option $dir/metadata.log run run_interrupted
     fi
 }
 
@@ -183,7 +183,8 @@ case $1 in
         metadata_log_end $dir $group
         name=$(basename $dir)
         if [ -f $pbench_tmp/$name.iterations ] ;then
-            pbench-add-metalog-option $pbench_tmp/$name.iterations $dir/metadata.log iterations
+            cat $pbench_tmp/$name.iterations |
+                pbench-add-metalog-option $dir/metadata.log pbench iterations
         fi
         ;;
     int)


### PR DESCRIPTION
Decompose iteration names into components, store them in the
the metadata log. These duplicate entries in the result JSON
file that pbench-uperf is producing, but it provides a convenient
place where the indexing script can pick them up.