### PR TITLE
Minimal changes needed to build an RPM successfully

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -237,7 +237,7 @@ install: install-destdir install-util-scripts install-bench-scripts install-tool
 	${COPY} profile ${DESTDIR}
 	${INSTALL} ${INSTALLOPTS} ${STOCKPILEDIR}
 	${COPY} stockpile ${DESTDIR}
-	${COPY} ../lib/configtools ${LIBDIR}
+	if [ -d ../lib/configtools ] ;then ${COPY} ../lib/configtools ${LIBDIR} ;fi
 
 install-destdir:
 	${INSTALL} ${INSTALLOPTS} ${DESTDIR}
@@ -268,6 +268,10 @@ install-tool-scripts: install-destdir
 	${INSTALL} ${INSTALLOPTS} ${TOOLDIR}/postprocess
 	cd tool-scripts/postprocess; \
 	${COPY} ${tool-postprocess} ${TOOLDIR}/postprocess
+
+install-build-artifacts:
+	${COPY} SHA1 ${DESTDIR}
+	if [ -f SEQNO ] ;then ${COPY} SEQNO ${DESTDIR} ;fi
 
 clean:
 	rm -rf ${DESTDIR}

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -55,7 +55,7 @@ tarball:
 	make -C .. DESTDIR=${TMPDIR}/${prog}-${VERSION}/agent
 	echo "${sha1}" > ${TMPDIR}/${prog}-${VERSION}/agent/SHA1
 	echo "${seqno}" > ${TMPDIR}/${prog}-${VERSION}/agent/SEQNO
-	tar zcf ${RPMSRC}/pbench-agent-${VERSION}.tar.gz -C ${TMPDIR} ${prog}-${VERSION}
+	tar zcf ${RPMSRC}/pbench-agent-${VERSION}.tar.gz --exclude-from ${CWD}/exclude.pats -C ${TMPDIR} ${prog}-${VERSION}
 	rm -rf ${TMPDIR}
 
 include rpm.mk

--- a/agent/rpm/exclude.pats
+++ b/agent/rpm/exclude.pats
@@ -6,3 +6,7 @@ unittests
 tests/
 mock-bin/
 util-scripts/configs/
+ansible/bin
+ansible/pbench/*
+ansible/pbench_*
+ansible/Makefile


### PR DESCRIPTION
A couple of changes in agent/Makefile:

- Copy ../lib/configtools if it exists: it will exist when we first
  build the tarball from rpm/Makefile, but it will not exist later
  when we invoke the agent/Makefile again to do the BUILDROOT installation
  from the spec file.

- The spec file needs an install-build-artifacts role to copy the
  generated SHA1 and (optional) SEQNO files.

The unversioned python shebang in ansible/bin/yamlconf caused an RPM build failure. The change
was to reactivate the exclude.pats file and add a couple of patterns to
exclude most of the ansible/ directory from the tarball.