### PR TITLE
Rebase and update `forward-port-trafficgen`

### DIFF
--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -19,13 +19,15 @@
 # If a run (with several samples) fails the stddev, its directory is appended with -fail.
 # This script will also generate a "results.txt" with a table of all results, efficiency, and other stats.
 
-pbench_cmd="${@}"
 script_path=$(dirname ${0})
 script_name=$(basename ${0})
 pbench_bin="$(realpath -e ${script_path}/..)"
 
+# Save the original command line invocation
+orig_cmd="${*}"
+
 # source the base script
-. "$pbench_bin"/base
+. ${pbench_bin}/base
 
 # Every bench-script follows a similar sequence:
 # 1) process bench script arguments
@@ -37,71 +39,72 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 # 7) postprocess analysis tool data
 
 benchmark_name="trafficgen"
-# Needed by pbench-metadata-log
 export benchmark=${benchmark_name}
 
-# Defaults
+# General pbench defaults
 export benchmark_run_dir=""
 export config=""
-traffic_generator_def="trex-txrx"
-traffic_generator="${traffic_generator_def}" # can be either trex-txrx or moongen-txrx
-trex_use_ht="n"
-trex_use_l2="n"
-traffic_directions_def="bidirectional"
-traffic_directions="${traffic_directions_def}"
+postprocess_only="n"
+tool_group="default"
+sysinfo="none"
+
+# Trafficgen specific defaults
+active_devices="" # the active network devices as PCI location IDs, like "0000:04:00.0,0000:04:00.1"
+all_possible_flow_mods="src-ip,dst-ip,src-mac,dst-mac,src-port,dst-port,encap-src-ip,encap-dst-ip,encap-src-mac,encap-dst-mac,protocol,none"
+devices="" # the network devices as PCI location IDs, like "0000:04:00.0,0000:04:00.1"
+df_search_runtime=120
+df_sniff_runtime=30
+df_validation_runtime=300
+df_zl_search_runtime=1200
+df_zl_sniff_runtime=30
+df_zl_validation_runtime=7200
+dst_ips=""
+dst_macs=""
+encap_dst_ips=""
+encap_dst_macs=""
+encap_src_ips=""
+encap_src_macs=""
+flow_mods_def="src-ip,dst-ip,src-mac,dst-mac"
+flow_mods="${flow_mods_def}"
+frame_sizes_def="64" # size in bytes of the Ethernet frame including CRC
+frame_sizes="${frame_sizes_def}"
+keep_failed_tool_data="y"
+max_failures=1 # after N failed attempts to hit below $maxstddevpct, move on to the nest test
 max_loss_pcts_def="0.002"
 max_loss_pcts="${max_loss_pcts_def}"
+maxstddevpct=5 # maximum allowable standard deviation in percent
 num_flows_def="1024"
 num_flows="${num_flows_def}"
 num_samples=1
-rates="none"
-rate_tolerance_pct=3 # by percent, how much the TX rate can vary from desired rate
-rate_unit="mpps"
-devices="" # the network devices as PCI location IDs, like "0000:04:00.0,0000:04:00.1"
-active_devices="" # the active network devices as PCI location IDs, like "0000:04:00.0,0000:04:00.1"
-dst_ips=""
-src_ips=""
-dst_macs=""
-src_macs=""
-encap_dst_ips=""
-encap_src_ips=""
-encap_dst_macs=""
-encap_src_macs=""
-frame_sizes_def="64"
-frame_sizes="${frame_sizes_def}" # size in bytes of the Ethernet frame including CRC
-maxstddevpct=5 # maximum allowable standard deviation in percent
-max_failures=1 # after N failed attempts to hit below $maxstddevpct, move on to the nest test
-df_sniff_runtime=30
-df_search_runtime=120
-df_validation_runtime=300
-df_zl_sniff_runtime=30
-df_zl_search_runtime=1200
-df_zl_validation_runtime=7200
-postprocess_only=n
-start_iteration_num=1
-keep_failed_tool_data="y"
-tar_nonref_data="n"
-orig_cmd="${*}"
-tool_group=default
 one_shot="n"
-skip_trex_install="n"
-skip_trex_server="n"
-skip_git_pull="n"
-flow_mods_def="src-ip,dst-ip,src-mac,dst-mac"
-flow_mods="${flow_mods_def}"
-all_possible_flow_mods="src-ip,dst-ip,src-mac,dst-mac,src-port,dst-port,encap-src-ip,encap-dst-ip,encap-src-mac,encap-dst-mac,protocol,none"
-cmd="./binary-search.py"
-passthrough_arguments=""
 packet_protocol_def="UDP"
 packet_protocol="${packet_protocol_def}"
+passthrough_arguments=""
 pre_sample_cmd=""
-traffic_profiles=""
-sysinfo="none"
+rate_tolerance_pct=3 # by percent, how much the TX rate can vary from desired rate
+rate_unit="mpps"
+rates="none"
+skip_git_pull="n"
+skip_trex_install="n"
+skip_trex_server="n"
+src_ips=""
+src_macs=""
+start_iteration_num=1
+tar_nonref_data="n"
 tool_period="binary-search" # can also be "repeat-final-validation"
-trafficgen_version="unknown"
+traffic_directions_def="bidirectional"
+traffic_directions="${traffic_directions_def}"
+traffic_generator_def="trex-txrx" # can be either trex-txrx or moongen-txrx
+traffic_generator="${traffic_generator_def}"
+traffic_profiles=""
 if [[ -z "${trafficgen_dir}" ]]; then
 	trafficgen_dir="/opt/trafficgen"
 fi
+trafficgen_version="unknown"
+trex_use_ht="n"
+trex_use_l2="n"
+
+cmd="./binary-search.py"
 
 function kill_trex() {
 	if [[ "${_PBENCH_UNIT_TESTS}" == 1 ]]; then
@@ -281,7 +284,7 @@ function usage {
 	printf -- "\n"
 	printf -- "--traffic-direction[s]=str[,str]\n"
 	printf -- "  A list of one or more: unidirectional, revunidirectional, or bidirectional\n"
-	printf -- "  (default ${traffic_directions_def})\n"
+	printf -- "  Default is ${traffic_directions_def}\n"
 	printf -- "  unidirectional: packets will Tx out the 1st device and Rx in the 2nd device\n"
 	printf -- "  revunidirectional: packets will Tx out the 2nd device and RX in the 1st device\n"
 	printf -- "  bidirectional: packets will Tx out the both devices and Rx in both devices\n"
@@ -295,7 +298,8 @@ function usage {
 	printf -- "  Default is ${frame_sizes_def}\n"
 	printf -- "\n"
 	printf -- "--num-flows=int\n"
-	printf -- "  Number of packet flows to run. Default is ${num_flows_def}\n"
+	printf -- "  Number of packet flows to run\n"
+	printf -- "  Default is ${num_flows_def}\n"
 	printf -- "\n\n"
 	#                   1         2         3         4         5         6         7         8
 	#          12345678901234567890123456789012345678901234567890123456789012345678901234567890
@@ -452,7 +456,7 @@ function usage {
 # Process options and arguments
 opts=$(getopt -q -o h --longoptions "pre-benchmark-cmd:,skip-trex-install,skip-trex-server,skip-git-pull,traffic-generator:,devices:,active-devices:,rate-unit:,rate:,rates:,rate-tolerance-pct:,max-loss-pct:,max-loss-pcts:,start-iteration-num:,config:,num-flows:,test-type:,traffic-direction:,traffic-directions:,sniff-runtime:,search-runtime:,validation-runtime:,frame-size:,frame-sizes:,samples:,max-stddev:,max-failures:,postprocess-only:,run-dir:,tool-group:,one-shot,src-ports:,dst-ports:,src-macs:,src-ips:,dst-macs:,dst-ips:,encap-src-macs:,encap-src-ips:,encap-dst-macs:,encapdst-ips:,vlan-ids:,overlay-ids:,overlay-types:,flow-mods:,packet-protocol:,trex-use-ht,trex-use-l2,traffic-profile:,traffic-profiles:,sysinfo:,tool-period:,help" -n "getopt.sh" -- "$@")
 if [ $? -ne 0 ]; then
-	printf -- "${script_name} ${*}\n\n\tunrecognized option specified\n\n" >&2
+	printf -- "%s %s\n\n\tunrecognized option specified\n\n" "${script_name}" "${*}" >&2
 	usage >&2
 	exit 1
 fi
@@ -700,6 +704,17 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+let errors=0
+for traffic_profile in `echo $traffic_profiles | sed -e s/,/" "/g`; do
+	if [[ ! -e "${traffic_profile}" ]]; then
+		error_log "Traffic profile, '${traffic_profile}', does not exist"
+		(( errors++ ))
+	fi
+done
+if [[ ${errors} -ne 0 ]]; then
+	exit 1
+fi
+
 if [ "$traffic_generator" == "trex-txrx" -o "$traffic_generator" == "moongen-txrx" -o "$traffic_generator" == "trex-txrx-profile" ]; then
 	cmd="$cmd --traffic-generator=$traffic_generator --rate-tolerance=$rate_tolerance_pct"
 else
@@ -752,17 +767,16 @@ if [ $one_shot == "y" ]; then
 	cmd="$cmd --one-shot=1"
 fi
 
-# register the tool triggers depending on the tool period preference
-# FIXME - Tool triggers should only be registered for the duration of the benchmark run.
-if [ "$tool_period" == "binary-search" ]; then
-	pbench-register-tool-trigger --group=$tool_group --start-trigger="Starting binary-search" --stop-trigger="Finished binary-search"
-elif [ "$tool_period" == "repeat-final-validation" ]; then
-	pbench-register-tool-trigger --group=$tool_group --start-trigger="Starting repeat final validation for debug collection" --stop-trigger="Finished repeat final validation for debug collection"
+if [[ "$tool_period" == "binary-search" ]]; then
+	start_trigger="Starting binary-search"
+	stop_trigger="Finished binary-search"
+elif [[ "$tool_period" == "repeat-final-validation" ]]; then
 	cmd="$cmd --repeat-final-validation"
-fi
-
-if [ -z "${active_devices}" ]; then
-	active_devices=${devices}
+	start_trigger="Starting repeat final validation for debug collection"
+	stop_trigger="Finished repeat final validation for debug collection"
+else
+	error_log "invalid --tool-period argument, '${tool_period}'"
+	exit 1
 fi
 
 if [ "${postprocess_only}" == "n" ]; then
@@ -810,6 +824,10 @@ if [ "${postprocess_only}" == "n" ]; then
 			error_log "only the trex-txrx* traffic generators support more than 1 pair of devices, exiting"
 			exit 1
 		fi
+	fi
+
+	if [ -z "${active_devices}" ]; then
+		active_devices=${devices}
 	fi
 
 	total_active_devices=$(echo ${active_devices} | sed -e "s/,/ /g" | wc -w)
@@ -903,30 +921,36 @@ fi
 # At this point all parameter checking has been done.
 ###
 
-# add test options to $config, so this test result directory is easily identifiable
-config="${config}_tg:$(echo ${traffic_generator} | sed -e 's/-txrx//')"
+# Build up a result directory identifier from parameters
+tg_config="tg:$(echo ${traffic_generator} | sed -e 's/-txrx//')"
 if [ $traffic_generator == "trex-txrx-profile" -a "${traffic_profiles}" != "" ]; then
 	traffic_profiles_list=""
-	for traffic_profile in `echo $traffic_profiles | sed -e s/,/" "/g`; do
+	for traffic_profile in $(echo ${traffic_profiles} | sed -e s/,/" "/g); do
 		traffic_profile=$(basename ${traffic_profile})
 		if [ -n "${traffic_profiles_list}" ]; then
 			traffic_profiles_list+=","
 		fi
 		traffic_profiles_list+="${traffic_profile}"
 	done
-	config="${config}_pf:${traffic_profiles_list}"
+	tg_config="${tg_config}_pf:${traffic_profiles_list}"
 else
-	config="${config}_r:${rates}"
-	config="${config}_fs:${frame_sizes}"
-	config="${config}_nf:${num_flows}"
-	config="${config}_fm:$(echo $flow_mods | sed -e 's/src-/s/g' -e 's/dst-/d/g' -e 's/ip/i/g' -e 's/mac/m/g' -e 's/port/p/g')"
-	config="${config}_td:$(echo $traffic_directions | sed -e 's/directional//g')"
+	tg_config="${tg_config}_r:${rates}"
+	tg_config="${tg_config}_fs:${frame_sizes}"
+	tg_config="${tg_config}_nf:${num_flows}"
+	tg_config="${tg_config}_fm:$(echo ${flow_mods} | sed -e 's/src-/s/g' -e 's/dst-/d/g' -e 's/ip/i/g' -e 's/mac/m/g' -e 's/port/p/g')"
+	tg_config="${tg_config}_td:$(echo ${traffic_directions} | sed -e 's/directional//g')"
 fi
-config="${config}_ml:${max_loss_pcts}"
+tg_config="${tg_config}_ml:${max_loss_pcts}"
 if [ "$one_shot" == "y" ]; then
-	config="${config}_tt:os"
+	tg_config="${tg_config}_tt:os"
 else
-	config="${config}_tt:bs"
+	tg_config="${tg_config}_tt:bs"
+fi
+# add test options to $config, so this test result directory is easily identifiable
+if [[ -z "${config}" ]]; then
+	config="${tg_config}"
+else
+	config="${config}_${tg_config}"
 fi
 
 if [[ -z "$benchmark_run_dir" ]]; then
@@ -978,36 +1002,26 @@ function record_profile_iteration {
 	echo ${iteration} | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
 }
 
-mkdir -p $benchmark_run_dir/.running
+if [ "${postprocess_only}" == "n" ]; then
+	mkdir -p $benchmark_run_dir/.running
 
-# now that the benchmark_run_dir directory exists, we can initialize the iterations file
-> ${benchmark_iterations}
+	# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+	> ${benchmark_iterations}
 
-# save a copy of the command, in case the test needs to be reproduced or post-processed again
-echo "$script_name $pbench_cmd" >$benchmark_run_dir/$script_name.cmd
-chmod +x $benchmark_run_dir/$script_name.cmd
+	# save a copy of the command, in case the test needs to be reproduced or post-processed again
+	echo "${script_name} ${orig_cmd}" > ${benchmark_run_dir}/${script_name}.cmd
+	chmod +x ${benchmark_run_dir}/${script_name}.cmd
+fi
 
 ## Run the benchmark and start/stop perf analysis tools
 
 total_iterations=0
-if [ ${traffic_generator} == "trex-txrx-profile" ]; then
-	if [ "${traffic_profiles}" != "" ]; then
-		for traffic_profile in `echo $traffic_profiles | sed -e s/,/" "/g`; do
-			for max_loss_pct in `echo $max_loss_pcts | sed -e s/,/" "/g`; do
-				((total_iterations++))
-			done
+if [ $traffic_generator == "trex-txrx-profile" -a "${traffic_profiles}" != "" ]; then
+	for traffic_profile in `echo $traffic_profiles | sed -e s/,/" "/g`; do
+		for max_loss_pct in `echo $max_loss_pcts | sed -e s/,/" "/g`; do
+			((total_iterations++))
 		done
-	else
-		for traffic_direction in `echo $traffic_directions | sed -e s/,/" "/g`; do
-			for frame_size in `echo $frame_sizes | sed -e s/,/" "/g`; do
-				for num_flow in `echo $num_flows | sed -e s/,/" "/g`; do
-					for max_loss_pct in `echo $max_loss_pcts | sed -e s/,/" "/g`; do
-						((total_iterations++))
-					done
-				done
-			done
-		done
-	fi
+	done
 else
 	for rate in `echo $rates | sed -e s/,/" "/g`; do
 		for traffic_direction in `echo $traffic_directions | sed -e s/,/" "/g`; do
@@ -1023,9 +1037,11 @@ else
 fi
 echo "Total number of benchmark iterations: $total_iterations"
 
-export benchmark=${benchmark_name}
-
 if [ "${postprocess_only}" == "n" ]; then
+	# Register the tool triggers depending on the tool period preference
+	# FIXME - tool triggers should only be registered for the duration of the benchmark run.
+	pbench-register-tool-trigger --group="${tool_group}" --start-trigger="${start_trigger}" --stop-trigger="${stop_trigger}"
+
 	# Start the tool meisters on each registered local/remote host
 	pbench-tool-meister-start --sysinfo="${sysinfo}" "${tool_group}"
 	if [[ ${?} != 0 ]]; then
@@ -1042,120 +1058,142 @@ if [ "${postprocess_only}" == "n" ]; then
 	fi
 fi
 
+function echo_log {
+	echo "${1}"
+	log "${1}"
+}
+
 pre_loop_cmd=${cmd}
 
 function inner_most_loop() {
-	local loop_type="${1}"
-	local rate_arg="${2}"
-	local traffic_direction_arg
-	local frame_size_arg
-	local num_flow_arg
-	local traffic_profile_arg
+	local loop_type=${1}
+	local traffic_profile_arg=${2}
+	local rate_arg=${3}
+	local traffic_direction_arg=${4}
+	local frame_size_arg=${5}
+	local num_flow_arg=${6}
 
-	if [[ ${loop_type} == "default" ]]; then
-		traffic_direction_arg="${3}"
-		frame_size_arg="${4}"
-		num_flow_arg="${5}"
-	elif [[ ${loop_type} == "profile" ]]; then
-		traffic_profile_arg="${3}"
+	if [[ "${loop_type}" == "default" ]]; then
+		local fs_unit="B"
+		unset traffic_profile_arg
+	elif [[ "${loop_type}" == "profile" ]]; then
+		local traffic_profile_name=$(basename ${traffic_profile_arg})
+		unset rate_arg
+		unset traffic_direction_arg
+		unset frame_size_arg
+		unset num_flow_arg
 	else
-		error_log "internal error - unexpected loop_type = '${loop_type}'"
+		error_log "INTERNAL ERROR - unexpected loop type, '${loop_type}'"
 		exit 1
 	fi
 
-	local iteration_sniff_runtime
-	local iteration_search_runtime
-	local iteration_validation_runtime
-
-	for max_loss_pct in `echo ${max_loss_pcts} | sed -e s/,/" "/g`; do
-		if [ ${rc} -ne 0 ]; then
+	for max_loss_pct in `echo $max_loss_pcts | sed -e s/,/" "/g`; do
+		if [[ ${rc} -ne 0 ]]; then
 			break
 		fi
 
-		if [ $count -ge $start_iteration_num ]; then
-			# reset the command to run
-			cmd=${pre_loop_cmd}
+		let count=${count}+1 # now we can move to the next iteration
 
-			# if any of the runtimes are provided by the user, then use those
-			unset iteration_sniff_runtime
-			unset iteration_search_runtime
-			unset iteration_validation_runtime
-			if [ ! -z "$sniff_runtime" ]; then
-				iteration_sniff_runtime=$sniff_runtime
-			fi
-			if [ ! -z "$search_runtime" ]; then
-				iteration_search_runtime=$search_runtime
-			fi
-			if [ ! -z "$validation_runtime" ]; then
-				iteration_validation_runtime=$validation_runtime
-			fi
-			# for any runtimes not provided by user, assign a default value
-			# there are different defaults for 0-loss and non-zero-loss
-			if [ -z "$iteration_sniff_runtime" ]; then
-				if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
-					iteration_sniff_runtime=$df_zl_sniff_runtime
-				else
-					iteration_sniff_runtime=$df_sniff_runtime
-				fi
-			fi
-			if [ -z "$iteration_search_runtime" ]; then
-				if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
-					iteration_search_runtime=$df_zl_search_runtime
-				else
-					iteration_search_runtime=$df_search_runtime
-				fi
-			fi
-			if [ -z "$iteration_validation_runtime" ]; then
-				if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
-					iteration_validation_runtime=$df_zl_validation_runtime
-				else
-					iteration_validation_runtime=$df_validation_runtime
-				fi
-			fi
-			cmd="$cmd --sniff-runtime=$iteration_sniff_runtime"
-			cmd="$cmd --search-runtime=$iteration_search_runtime"
-			cmd="$cmd --validation-runtime=$iteration_validation_runtime"
+		if [ "${loop_type}" == "default" ]; then
+			iteration="${count}-${rate_arg}-${traffic_direction_arg}-${frame_size_arg}${fs_unit}-${num_flow_arg}flows-${max_loss_pct}pct_drop"
+		else
+			iteration="${count}-${traffic_profile_name}-${max_loss_pct}pct_drop"
+		fi
 
-			local iteration
+		if [[ ${count} -lt ${start_iteration_num} ]]; then
+			echo_log "Skipping iteration ${iteration} (${count} of ${total_iterations})"
+			continue
+		fi
 
-			if [[ "${loop_type}" == "default" ]]; then
-				local fs_unit=""
-				if [ ${frame_size_arg} -eq "${frame_size_arg}" ] 2>/dev/null; then
-					fs_unit="B"
-				fi
-				iteration="${count}-${rate_arg}-${traffic_direction_arg}-${frame_size_arg}${fs_unit}-${num_flow_arg}flows-${max_loss_pct}pct_drop"
-				if [ "${postprocess_only}" == "n" ]; then
-					record_default_iteration "${count}" "${rate_arg}" "${traffic_direction_arg}" "${frame_size_arg}${fs_unit}" "${num_flow_arg}flows" "${max_loss_pct}pct_drop" "${iteration}"
-				fi
+		if [ "${postprocess_only}" == "n" ]; then
+			if [ "${loop_type}" == "default" ]; then
+				record_default_iteration "${count}" "${rate_arg}" "${traffic_direction_arg}" "${frame_size_arg}${fs_unit}" "${num_flow_arg}flows" "${max_loss_pct}pct_drop" "${iteration}"
 			else
-				if [ "${loop_type}" != "profile" ]; then
-					error_log "internal error - logic bomb!  unexpected loop_type = '${loop_type}'"
-					exit 1
-				fi
-				local tmp_traffic_profile=$(basename ${traffic_profile})
-				iteration="${count}-${tmp_traffic_profile}-${max_loss_pct}pct_drop"
-				if [ "${postprocess_only}" == "n" ]; then
-					record_profile_iteration "${count}" "${tmp_traffic_profile}" "${max_loss_pct}pct_drop" "${iteration}"
-				fi
+				record_profile_iteration "${count}" "${traffic_profile_name}" "${max_loss_pct}pct_drop" "${iteration}"
 			fi
+		fi
 
-			tt_iteration_dir="${benchmark_run_dir}/${count}-default"
-			iteration_dir="$benchmark_run_dir/$iteration"
-			if [ "${postprocess_only}" == "n" ]; then
-				mkdir -p $iteration_dir
+		# reset the command to run
+		cmd=${pre_loop_cmd}
+
+		# if any of the runtimes are provided by the user, then use those
+		unset iteration_sniff_runtime
+		unset iteration_search_runtime
+		unset iteration_validation_runtime
+		if [ ! -z "$sniff_runtime" ]; then
+			iteration_sniff_runtime=$sniff_runtime
+		fi
+		if [ ! -z "$search_runtime" ]; then
+			iteration_search_runtime=$search_runtime
+		fi
+		if [ ! -z "$validation_runtime" ]; then
+			iteration_validation_runtime=$validation_runtime
+		fi
+		# for any runtimes not provided by user, assign a default value
+		# there are different defaults for 0-loss and non-zero-loss
+		if [ -z "$iteration_sniff_runtime" ]; then
+			if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
+				iteration_sniff_runtime=$df_zl_sniff_runtime
+			else
+				iteration_sniff_runtime=$df_sniff_runtime
 			fi
-			benchmark_cmd_file="$iteration_dir/$benchmark_name.cmd"
-			result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
-			failures=0
+		fi
+		if [ -z "$iteration_search_runtime" ]; then
+			if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
+				iteration_search_runtime=$df_zl_search_runtime
+			else
+				iteration_search_runtime=$df_search_runtime
+			fi
+		fi
+		if [ -z "$iteration_validation_runtime" ]; then
+			if [[ $(echo "if (${max_loss_pct} == 0) 1 else 0" | bc) -eq 1 ]]; then
+				iteration_validation_runtime=$df_zl_validation_runtime
+			else
+				iteration_validation_runtime=$df_validation_runtime
+			fi
+		fi
+		cmd="$cmd --sniff-runtime=$iteration_sniff_runtime"
+		cmd="$cmd --search-runtime=$iteration_search_runtime"
+		cmd="$cmd --validation-runtime=$iteration_validation_runtime"
+
+		tt_iteration_dir="${benchmark_run_dir}/${count}-default"
+		iteration_dir="$benchmark_run_dir/$iteration"
+
+		if [ "${postprocess_only}" == "n" ]; then
+			mkdir -p $iteration_dir
 
 			local iteration_options="--max-loss-pct=${max_loss_pct}"
-			if [ "${loop_type}" == "default" ]; then
-				if [ ${rate_arg} == "none" ]; then
-					if [ ${traffic_generator} == "trex-txrx" ]; then
+			if [[ ${traffic_generator} == "trex-txrx-profile" ]]; then
+				if [[ "${traffic_profile_arg}" == "" || "${rates}" == "none" ]]; then
+					iteration_options="${iteration_options} --rate-unit=% --rate=100"
+				else
+					iteration_options="${iteration_options} --rate-unit=% --rate=${rates}"
+				fi
+				if [[ "${traffic_profile_arg}" == "" ]]; then
+					profile_builder_cmd_file="${iteration_dir}/profile-builder.cmd"
+
+					echo "pushd ${trafficgen_dir} > /dev/null" > ${profile_builder_cmd_file}
+					echo "./profile-builder.py --frame-size=${frame_size_arg} --num-flows=${num_flow_arg} --rate=${rate_arg} ${profile_flow_mods} --traffic-direction=${traffic_direction_arg} --measure-latency" >> ${profile_builder_cmd_file}
+					echo "cmd_rc=\${?}" >> ${profile_builder_cmd_file}
+					echo "popd > /dev/null" >> ${profile_builder_cmd_file}
+					echo "exit \${cmd_rc}" >> ${profile_builder_cmd_file}
+					chmod +x ${profile_builder_cmd_file}
+
+					traffic_profile_file="${iteration_dir}/traffic-profile.json"
+
+					${profile_builder_cmd_file} > ${traffic_profile_file} 2>&1
+				else
+					cp ${traffic_profile_arg} ${iteration_dir}/
+					traffic_profile_file="${iteration_dir}/${traffic_profile_name}"
+				fi
+				iteration_options="${iteration_options} --traffic-profile=${traffic_profile_file}"
+			else
+				if [[ ${rate_arg} == "none" ]]; then
+					if [[ ${traffic_generator} == "trex-txrx" ]]; then
 						iteration_options="${iteration_options} --rate-unit=% --rate=100"
 					else
 						# don't specify a rate and let binary-search.py + whatever traffic-generator figure it out
-						:
+						iteration_options="${iteration_options}"
 					fi
 				else
 					iteration_options="${iteration_options} --rate-unit=${rate_unit} --rate=${rate_arg}"
@@ -1163,203 +1201,149 @@ function inner_most_loop() {
 				iteration_options="${iteration_options} --traffic-direction=${traffic_direction_arg}"
 				iteration_options="${iteration_options} --frame-size=${frame_size_arg}"
 				iteration_options="${iteration_options} --num-flows=${num_flow_arg}"
-			else
-				if [ ${traffic_generator} != "trex-txrx-profile" ]; then
-					error_log "internal error - logic bomb!  expected 'trex-txrx-profile' traffic_generator, not '${loop_type}'"
-					exit 1
-				fi
-				if [[ "${loop_type}" != "profile" ]]; then
-					error_log "internal error - logic bomb!  unexpected loop_type = '${loop_type}'"
-					exit 1
-				fi
-				if [ "${traffic_profiles}" == "" ]; then
-					traffic_profile_file="${iteration_dir}/traffic-profile.json"
-					if [[ "${postprocess_only}" == "n" ]]; then
-						if [ "${rate_arg}" == "none" ]; then
-							# Default the profile builder rate argument.
-							pb_rate_arg=""
-						else
-							if [[ "${rate_unit}" != "mpps" ]]; then
-								warn_log "Specified rate, '${rate_arg}' is not in millions of packets per sec (mpps), ignoring"
-								pb_rate_arg=""
-							else
-								pb_rate_arg="--rate=${rate_arg}"
-							fi
-						fi
-
-						profile_builder_cmd_file="${iteration_dir}/profile-builder-cmd"
-
-						echo "pushd $trafficgen_dir >/dev/null" >${profile_builder_cmd_file}
-						echo "./profile-builder.py --frame-size=${frame_size_arg} --num-flows=${num_flow_arg} ${pb_rate_arg} ${profile_flow_mods} --traffic-direction=${traffic_direction_arg} --measure-latency" >>${profile_builder_cmd_file}
-						echo "cmd_rc=\$?" >>${profile_builder_cmd_file}
-						echo "popd >/dev/null" >>${profile_builder_cmd_file}
-						echo "exit" >>${profile_builder_cmd_file}
-						chmod +x ${profile_builder_cmd_file}
-
-
-						${profile_builder_cmd_file} > ${traffic_profile_file} 2>&1
-					elif [[ ! -e "${traffic_profile_file}" ]]; then
-						warn_log "Missing expected traffic profile '${traffic_profile_file}'"
-					fi
-				else
-					cp ${traffic_profile} ${iteration_dir}/
-					traffic_profile_file="${iteration_dir}/`basename ${traffic_profile}`"
-				fi
-				iteration_options="${iteration_options} --traffic-profile=${traffic_profile_file}"
 			fi
 
-			if [[ "${postprocess_only}" == "n" ]]; then
-				# save benchmark command in file for debugging or running manually
-				echo "pushd >/dev/null $trafficgen_dir" >$benchmark_cmd_file
-				echo "$cmd $iteration_options $passthrough_arguments \$@" >>$benchmark_cmd_file
-				echo "cmd_rc=\$?" >>$benchmark_cmd_file
-				echo "popd >/dev/null" >>$benchmark_cmd_file
-				echo "exit \$cmd_rc" >>$benchmark_cmd_file
-				chmod +x $benchmark_cmd_file
+			# save benchmark command in file for debugging or running manually
+			benchmark_cmd_file="${iteration_dir}/${benchmark_name}.cmd"
+			echo "pushd ${trafficgen_dir} > /dev/null" > ${benchmark_cmd_file}
+			echo "${cmd} ${iteration_options} ${passthrough_arguments} \${@}" >> ${benchmark_cmd_file}
+			echo "cmd_rc=\${?}" >> ${benchmark_cmd_file}
+			echo "popd > /dev/null" >> ${benchmark_cmd_file}
+			echo "exit \${cmd_rc}" >> ${benchmark_cmd_file}
+			chmod +x ${benchmark_cmd_file}
+		fi
+
+		echo_log "Starting iteration[$iteration] ($count of $total_iterations)"
+
+		result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
+		failures=0
+		while [[ $(echo "if (${result_stddevpct} >= ${maxstddevpct}) 1 else 0" | bc) -eq 1 ]]; do
+			if [[ ${failures} -gt 0 ]]; then
+				echo_log "Restarting iteration[$iteration] ($count of $total_iterations)"
 			fi
-
-			local iter_msg="Starting iteration[${iteration}] (${count} of ${total_iterations})"
-			echo "${iter_msg}"
-			log "${iter_msg}"
-
-			while [[ $(echo "if (${result_stddevpct} >= ${maxstddevpct}) 1 else 0" | bc) -eq 1 ]]; do
-				if [[ $failures -gt 0 ]]; then
-					iter_msg="Restarting iteration[${iteration}] (${count} of ${total_iterations})"
-					echo "${iter_msg}"
-					log "${iter_msg}"
-				fi
-				# each attempt at a test config requires multiple samples to get stddev
-				for sample in `seq 1 $num_samples`; do
-					if [ $rc -ne 0 ]; then
-						break
-					fi
-					sample_name="sample${sample}"
-					benchmark_results_dir="${iteration_dir}/${sample_name}"
-					tt_benchmark_results_dir="${tt_iteration_dir}/${sample_name}"
-					if [ "$postprocess_only" != "y" ]; then
-						mkdir -p $benchmark_results_dir
-						echo "test sample $sample of $num_samples"
-						log "test sample $sample of $num_samples"
-						pre_benchmark_cmd_log=$benchmark_results_dir/pre-benchmark-cmd-log.txt
-						result_file=$benchmark_results_dir/result.txt
-						if [ "$pre_benchmark_cmd" != "" ]; then
-							PBENCH_ITERATION=$iteration PBENCH_SAMPLE=$sample $pre_benchmark_cmd 2>&1 | tee -i $pre_benchmark_cmd_log
-						fi
-						${benchmark_cmd_file} --output-dir=${benchmark_results_dir} 2>&1 | pbench-tool-trigger "${count}" "${benchmark_run_dir}" ${tool_group} ${sample} | tee -i ${result_file}
-						rc=$?
-						if [ $rc -ne 0 ]; then
-							error_log "iteration ${iteration} sample ${sample} returned non-zero exit code - ${rc}"
-							pbench-stop-tools --group=${tool_group} --dir=${tt_benchmark_results_dir}
-						fi
-
-						if [[ -e "${tt_benchmark_results_dir}/tools-${tool_group}" ]]; then
-							# Collect any remote tool data now
-							pbench-send-tools --group=${tool_group} --dir=${tt_benchmark_results_dir}
-
-							# Move the tool data collected for the tool-group to its final resting place.
-							mv ${tt_benchmark_results_dir}/tools-${tool_group} ${benchmark_results_dir}/
-							if [[ ${?} -ne 0 ]]; then
-								error_log "INTERNAL ERROR: failed to move tool-trigger data, '${tt_benchmark_results_dir}/tools-${tool_group}' to '${benchmark_results_dir}'"
-								exit 1
-							fi
-							# The "tool-trigger" sample directory should be empty now.
-							rmdir ${tt_benchmark_results_dir}
-							if [[ ${?} -ne 0 ]]; then
-								error_log "INTERNAL ERROR: failed to remove tool-trigger results directory, '${tt_benchmark_results_dir}'"
-								exit 1
-							fi
-						else
-							msg="tool triggers did not fire for iteration/sample, '${iteration}/${sample_name}'"
-							echo "${msg}"; log "${msg}"
-						fi
-					else
-						if [[ ! -d $benchmark_results_dir ]]; then
-							error_log "Results directory $benchmark_results_dir does not exist, skipping post-processing"
-							continue
-						fi
-						echo "Not going to run $benchmark_name.  Only postprocesing existing data"
-						log "Not going to run $benchmark_name.  Only postprocesing existing data"
-					fi
-					if [ $rc -eq 0 ]; then
-						pbench-postprocess-tools --group=${tool_group} --dir=${benchmark_results_dir}
-						local traffic_profile_arg=""
-						if [[ ! -z "${traffic_profile}" ]]; then
-							traffic_profile_arg="$(basename ${traffic_profile})"
-						fi
-						echo "${script_path}/postprocess/${benchmark_name}-postprocess \"${benchmark_results_dir}\" \"${_pbench_full_hostname}\" \"${rate_arg}\" \"${frame_size_arg}\" \"${num_flow_arg}\" \"${traffic_profile_arg}\" \"${trafficgen_version}\"" >"$benchmark_results_dir/$benchmark_name-postprocess.cmd"
-						chmod +x "$benchmark_results_dir/$benchmark_name-postprocess.cmd"
-						$benchmark_results_dir/$benchmark_name-postprocess.cmd 2>&1 | tee $benchmark_results_dir/$benchmark_name-postprocess.out || rc=1
-					fi
-				done
-				if [ $rc -eq 0 ]; then
-					echo "$script_path/postprocess/process-iteration-samples \"$iteration_dir\" Mframes_sec \"$maxstddevpct\" \"$failures\" \"$max_failures\" \"$tar_nonref_data\" \"$keep_failed_tool_data\"" >"$iteration_dir/process-iteration-samples.cmd"
-					chmod +x "$iteration_dir/process-iteration-samples.cmd"
-					$iteration_dir/process-iteration-samples.cmd 2>&1 | tee $iteration_dir/process-iteration-samples.out
-					fail=$?
-					if [ $fail -ne 0 -a $fail -ne 1 ]; then
-						error_log "process-iteration-samples generated an unknown error, aborting"
-						exit 1
-					fi
-					if [ $fail -eq 1 ]; then
-						error_log "This test iteration failed"
-						((failures++))
-					fi
-					if [ $fail -eq 0 -o $failures -ge $max_failures ]; then
-						debug_log "Moving to the next iteration"
-						break
-					fi
-				else
-					error_log "Aborting benchmark"
+			# each attempt at a test config requires multiple samples to get stddev
+			for sample in `seq 1 $num_samples`; do
+				if [ $rc -ne 0 ]; then
 					break
 				fi
-			done # break out of this loop only if the $result_stddevpct is lower than $maxstddevpct
+				benchmark_results_dir="$iteration_dir/sample$sample"
+				tt_benchmark_results_dir="${tt_iteration_dir}/sample${sample}"
+				if [ "$postprocess_only" != "y" ]; then
+					mkdir -p $benchmark_results_dir
+					echo_log "test sample $sample of $num_samples"
+					pre_benchmark_cmd_log=$benchmark_results_dir/pre-benchmark-cmd-log.txt
+					result_file=$benchmark_results_dir/result.txt
+					if [ "$pre_benchmark_cmd" != "" ]; then
+						PBENCH_ITERATION=$iteration PBENCH_SAMPLE=$sample $pre_benchmark_cmd 2>&1 | tee -i $pre_benchmark_cmd_log
+					fi
+					${benchmark_cmd_file} --output-dir=${benchmark_results_dir} 2>&1 | pbench-tool-trigger "${count}" "${benchmark_run_dir}" ${tool_group} ${sample} | tee -i ${result_file}
+					rc=$?
+					if [ $rc -ne 0 ]; then
+						error_log "iteration ${iteration} sample ${sample} returned non-zero exit code, ${rc}"
+						pbench-stop-tools --group=${tool_group} --dir=${tt_benchmark_results_dir}
+					fi
+
+					if [[ -e "${tt_benchmark_results_dir}/tools-${tool_group}" ]]; then
+						# Collect any remote tool data now
+						pbench-send-tools --group=${tool_group} --dir=${tt_benchmark_results_dir}
+
+						# Move the tool data collected for the tool-group to its final resting place.
+						mv ${tt_benchmark_results_dir}/tools-${tool_group} ${benchmark_results_dir}/
+						if [[ ${?} -ne 0 ]]; then
+							error_log "INTERNAL ERROR: failed to move tool-trigger data, '${tt_benchmark_results_dir}/tools-${tool_group}' to '${benchmark_results_dir}'"
+							exit 1
+						fi
+						# The "tool-trigger" sample directory should be empty now.
+						rmdir ${tt_benchmark_results_dir}
+						if [[ ${?} -ne 0 ]]; then
+							error_log "INTERNAL ERROR: failed to remove tool-trigger results directory, '${tt_benchmark_results_dir}'"
+							exit 1
+						fi
+					else
+						echo_log "tool triggers did not fire for iteration/sample, '${iteration}/sample${sample}'"
+					fi
+				else
+					if [[ ! -d $benchmark_results_dir ]]; then
+						error_log "Results directory $benchmark_results_dir does not exist, skipping post-processing"
+						continue
+					fi
+					echo_log "Not going to run $benchmark_name.  Only postprocesing existing data"
+				fi
+				if [ $rc -eq 0 ]; then
+					# Post-process the collected tool data now
+					pbench-postprocess-tools --group=${tool_group} --dir=${tt_benchmark_results_dir}
+
+					echo "${script_path}/postprocess/${benchmark_name}-postprocess \"${benchmark_results_dir}\" \"${full_hostname}\" \"${rate_arg}\" \"${frame_size_arg}\" \"${num_flow_arg}\" \"${traffic_profile_name}\" \"${trafficgen_version}\"" > "${benchmark_results_dir}/${benchmark_name}-postprocess.cmd"
+					chmod +x "${benchmark_results_dir}/${benchmark_name}-postprocess.cmd"
+					${benchmark_results_dir}/${benchmark_name}-postprocess.cmd 2>&1 | tee ${benchmark_results_dir}/${benchmark_name}-postprocess.out || rc=1
+				fi
+			done
 			if [ $rc -eq 0 ]; then
-				echo "Iteration $iteration complete ($count of $total_iterations), with 1 pass and $failures failures"
-				log "Iteration $iteration complete ($count of $total_iterations), with 1 pass and $failures failures"
-			fi
-			if [[ "$postprocess_only" != "y" && -e "${tt_iteration_dir}" ]]; then
-				# Remove this iteration's "tool-trigger" directory.
-				rmdir ${tt_iteration_dir}
-				if [[ ${?} -ne 0 ]]; then
-					error_log "INTERNAL ERROR: failed to remove tool-trigger directory, '${tt_iteration_dir}'"
+				echo "$script_path/postprocess/process-iteration-samples \"$iteration_dir\" Mframes_sec \"$maxstddevpct\" \"$failures\" \"$max_failures\" \"$tar_nonref_data\" \"$keep_failed_tool_data\"" >"$iteration_dir/process-iteration-samples.cmd"
+				chmod +x "$iteration_dir/process-iteration-samples.cmd"
+				$iteration_dir/process-iteration-samples.cmd 2>&1 | tee $iteration_dir/process-iteration-samples.out
+				fail=$?
+				if [ $fail -ne 0 -a $fail -ne 1 ]; then
+					error_log "process-iteration-samples generated an unknown error, aborting"
 					exit 1
 				fi
+				if [ $fail -eq 1 ]; then
+					error_log "This test iteration failed"
+					((failures++))
+				fi
+				if [ $fail -eq 0 -o $failures -ge $max_failures ]; then
+					debug_log "Moving to the next iteration"
+					break
+				fi
+			else
+				error_log "Aborting benchmark"
+				break
 			fi
-		else
-			echo "Skipping iteration $iteration ($count of $total_iterations)"
-			log "Skipping iteration $iteration ($count of $total_iterations)"
+		done # break out of this loop only if the $result_stddevpct is lower than $maxstddevpct
+		if [ $rc -eq 0 ]; then
+			echo_log "Iteration $iteration complete ($count of $total_iterations), with 1 pass and $failures failures"
 		fi
-		let count=$count+1 # now we can move to the next iteration
+		if [[ "$postprocess_only" != "y" && -e "${tt_iteration_dir}" ]]; then
+			# Remove this iteration's "tool-trigger" directory.
+			rmdir ${tt_iteration_dir}
+			if [[ ${?} -ne 0 ]]; then
+				error_log "INTERNAL ERROR: failed to remove tool-trigger directory, '${tt_iteration_dir}'"
+				exit 1
+			fi
+		fi
 	done
 }
 
-count=1
+# Inner loop now pre-increments
+count=0
 rc=0
 if [[ ${traffic_generator} == "trex-txrx-profile" && "${traffic_profiles}" != "" ]]; then
 	for traffic_profile in `echo ${traffic_profiles} | sed -e s/,/" "/g`; do
-		if [ ${rc} -ne 0 ]; then
+		if [[ ${rc} -ne 0 ]]; then
 			break
 		fi
-		inner_most_loop "profile" "${rates}" "${traffic_profile}"
+
+		inner_most_loop "profile" "${traffic_profile}" "no-rate" "no-traffic-direction" "no-frame-size" "no-num-flow"
 	done
 else
-	for rate in `echo $rates | sed -e s/,/" "/g`; do
-		if [ ${rc} -ne 0 ]; then
+	for rate in `echo ${rates} | sed -e s/,/" "/g`; do
+		if [[ ${rc} -ne 0 ]]; then
 			break
 		fi
-		for traffic_direction in `echo $traffic_directions | sed -e s/,/" "/g`; do
-			if [ ${rc} -ne 0 ]; then
+		for traffic_direction in `echo ${traffic_directions} | sed -e s/,/" "/g`; do
+			if [[ ${rc} -ne 0 ]]; then
 				break
 			fi
-			for frame_size in `echo $frame_sizes | sed -e s/,/" "/g`; do
-				if [ ${rc} -ne 0 ]; then
+			for frame_size in `echo ${frame_sizes} | sed -e s/,/" "/g`; do
+				if [[ ${rc} -ne 0 ]]; then
 					break
 				fi
-				for num_flow in `echo $num_flows | sed -e s/,/" "/g`; do
-					if [ ${rc} -ne 0 ]; then
+				for num_flow in `echo ${num_flows} | sed -e s/,/" "/g`; do
+					if [[ ${rc} -ne 0 ]]; then
 						break
 					fi
-					inner_most_loop "default" "${rate}" "${traffic_direction}" "${frame_size}" "${num_flow}"
+
+					inner_most_loop "default" "no-traffic-profile" "${rate}" "${traffic_direction}" "${frame_size}" "${num_flow}"
 				done
 			done
 		done
@@ -1387,6 +1371,6 @@ if [ "${postprocess_only}" == "n" ]; then
 	if [[ ${?} != 0 ]]; then
 		error_log "[${script_name}]: failed to stop the tool meisters."
 	fi
-fi
 
-rmdir $benchmark_run_dir/.running
+	rmdir $benchmark_run_dir/.running
+fi


### PR DESCRIPTION
This PR shows the effect of rebasing the current `portante/pbench/forward-port-trafficgen` on the current end of `distributed-system-analysis/pbench/main`, after all the required merges have been performed.

The net effect is that `agent/bench-scripts/postprocess/process-iteration-samples` and `agent/bench-scripts/postprocess/trafficgen-postprocess` no longer require changes and so they no longer appear as changed on the branch, and only `agent/bench-scripts/pbench-trafficgen` remains (and it is unchanged as a result of the rebase).  (Contrary to GitHub's helpful assertions, there should be only 1 commit containing 1 file, not 132 containing 427.  😆)

Because of the rebase, my branch here cannot be automatically merged into the upstream (i.e., I needed to do a `push -f`, which I don't have permission to do).  So, instead of merging this PR, I would recommend doing a rebase and resolving the merge conflicts by selecting the `main` versions for everything except `pbench-trafficgen` (which should be taken from the `forward-port-trafficgen` branch without modification).